### PR TITLE
Prepare FreeSurfer 6.0.0-beta image

### DIFF
--- a/crn_base/Dockerfile_fs6
+++ b/crn_base/Dockerfile_fs6
@@ -1,0 +1,71 @@
+# Copyright (c) 2017, The developers of the Stanford CRN
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of crn_base nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM poldracklab/neuroimaging-core:base-0.0.2
+MAINTAINER Stanford Center for Reproducible Neuroscience <crn.poldracklab@gmail.com>
+
+ENV FS_URL='ftp://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/6.0.0-beta/freesurfer-Linux-centos6_x86_64-stable-v6-beta-20161028-4cfbf2a.tar.gz'
+
+#  FreeSurfer installation
+RUN curl -sSL $FS_URL \
+    | tar zx -C /opt \
+    --exclude='freesurfer/trctrain' \
+    --exclude='freesurfer/subjects/fsaverage_sym' \
+    --exclude='freesurfer/subjects/fsaverage3' \
+    --exclude='freesurfer/subjects/fsaverage4' \
+    --exclude='freesurfer/subjects/fsaverage5' \
+    --exclude='freesurfer/subjects/fsaverage6' \
+    --exclude='freesurfer/subjects/cvs_avg35' \
+    --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
+    --exclude='freesurfer/subjects/bert' \
+    --exclude='freesurfer/subjects/V1_average' \
+    --exclude='freesurfer/average/mult-comp-cor' \
+    --exclude='freesurfer/lib/cuda' \
+    --exclude='freesurfer/lib/qt' && \
+    /bin/bash -c 'touch /opt/freesurfer/.license'
+#  End Freesurfer installation
+
+ENV OS=Linux \
+    FS_OVERRIDE=0 \
+    FIX_VERTEX_AREA= \
+    SUBJECTS_DIR=/opt/freesurfer/subjects \
+    FSF_OUTPUT_FORMAT=nii.gz \
+    MNI_DIR=/opt/freesurfer/mni \
+    LOCAL_DIR=/opt/freesurfer/local \
+    FREESURFER_HOME=/opt/freesurfer \
+    FSFAST_HOME=/opt/freesurfer/fsfast \
+    MINC_BIN_DIR=/opt/freesurfer/mni/bin \
+    MINC_LIB_DIR=/opt/freesurfer/mni/lib \
+    MNI_DATAPATH=/opt/freesurfer/mni/data \
+    FMRI_ANALYSIS_DIR=/opt/freesurfer/fsfast \
+    PERL5LIB=/opt/freesurfer/mni/lib/perl5/5.8.5 \
+    MNI_PERL5LIB=/opt/freesurfer/mni/lib/perl5/5.8.5
+
+ENV PATH=$FREESURFER_HOME/bin:$FSFAST_HOME/bin:$FREESURFER_HOME/tktools:$MINC_BIN_DIR:$PATH
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
First step for poldracklab/fmriprep#101.

What's the overall strategy for updating these base images? Should we have a Makefile that publishes, or a circle.yml that builds and publishes when necessary?

Or is this repo obsolete? I noticed poldracklab/fmriprep#320 moved away from the `crn_*` setup.